### PR TITLE
Refactor: remove 'require:pry' from each class and add replit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # connect4_bc
 
-Enter `$ruby runner.rb` to play game
+From the command line:
+- Enter `$ruby runner.rb` to start the game
+
+Or visit our replit [here](https://replit.com/@zorromcleod/connect4game#lib/board.rb):
+- Once the page loads, click the green 'Run' button to start the game

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require './lib/space'
 require './lib/player'
 class Board

--- a/lib/computer.rb
+++ b/lib/computer.rb
@@ -1,4 +1,3 @@
-
 require './lib/player'
 require './lib/board'
 require './lib/space'

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require './lib/board'
 # a Player object needs to be passed the same Board as the Computer and WinChecker.
 class Player

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require './lib/board'
 require './lib/player'
 class Space

--- a/lib/win_checker.rb
+++ b/lib/win_checker.rb
@@ -2,7 +2,6 @@ require './lib/board'
 require './lib/player'
 require './lib/space'
 require './lib/computer'
-require 'pry'
 # WinChecker is given a board, player, and computer in order to be able to read the Spaces, and change the value of has_won?
 class WinChecker
   attr_reader :board

--- a/spec/win_checker_spec.rb
+++ b/spec/win_checker_spec.rb
@@ -164,6 +164,7 @@ describe WinChecker do
     game_status.check_diagonal_wins
     game_status.check_vertical_wins
     game_status.check_horizontal_wins
+    require 'pry'; binding.pry
     expect(game_status.is_a_draw?).to eq("It's a draw!!")
     end
 


### PR DESCRIPTION
Just removed the pry statements,  my thinking is that we are done testing so we shouldn't need them anymore. Also updated the README with a replit so we can easily share it with other people. 